### PR TITLE
Use SighticInferenceView from the SDK version 0.0.40 instead of the SighticView.

### DIFF
--- a/SighticQuickstartSwiftUI/SighticQuickstartSwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SighticQuickstartSwiftUI/SighticQuickstartSwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/EyescannerTechnology/sightic-sdk-ios",
       "state" : {
         "branch" : "main",
-        "revision" : "cbffc16a138e78bb603ff53613ae1be2c6e64354"
+        "revision" : "2f590173e97288f19a12da96d0f50ab04a96156c"
       }
     }
   ],

--- a/SighticQuickstartSwiftUI/SighticQuickstartSwiftUI/TestView.swift
+++ b/SighticQuickstartSwiftUI/SighticQuickstartSwiftUI/TestView.swift
@@ -1,37 +1,19 @@
-//
-//  TestView.swift
-//  SighticQuickstartSwiftUI
-//
 //  Copyright © 2022 Sightic Analytics AB All rights reserved.
-//
 
 import SwiftUI
 import SighticAnalytics
 
-/// The ``TestView`` acts as a container view for the ``SighticView``.
+/// The ``TestView`` acts as a container view for the ``SighticInferenceView``.
 ///
-/// 1. Create a ``SighticView`` and let it occupy the whole screen.
-/// 2. Provide an API key to the ``SighticView``.
-/// 3. Provide a limit on how many times the app user is allow to fail
-///   to do a recording before triggering completion handler with an error.
-/// 3. Provide a completion handler to SighticView
-///    - The completion handler will receive a
-///      ``SighticRecordingResult`` which is of type ``Result``.
-///    - ``SighticRecordingResult`` case ``.success`` contains ``SighticRecording``
-///    - ``SighticRecordingResult`` case ``.failure`` contains ``SighticError``.
-/// 4. ``SighticRecording`` implements the function ``performInference`` that sends the
-///   recording to the Sightic backend for analysis.
-/// 5. The ``performInference`` function returns a ``SighticInferenceResult``
-///   which is of type ``Result``:
-///     - ``SighticInferenceResult`` case ``.success`` contains ``SighticResult``
-///     - ``SighticInferenceResult`` case ``.failure`` contains  ``SighticError``.
+/// See https://github.com/EyescannerTechnology/sightic-sdk-ios/blob/main/README.md
+/// regarding how to use the ``SighticInferenceView`` view.
 struct TestView: View {
     @Binding var appState: AppState
 
-    func sendRecodingForAnalysis(_ sighticRecording: SighticRecording) {
+    func sendRecodingForAnalysis(_ sighticInferenceRecording: SighticInferenceRecording) {
         Task {
             /*
-             - The app now has a SighticRecording that we can call
+             - The app now has a sighticInferenceRecording that we can call
                performInference on to send the recording Sightic server
                for analysis.
 
@@ -43,7 +25,7 @@ struct TestView: View {
                will be used in the ResultView.
              */
             appState = .waitingForAnalysis
-            let inferenceResult = await sighticRecording.performInference()
+            let inferenceResult = await sighticInferenceRecording.performInference()
             switch inferenceResult {
             case .success(let sighticInference):
                 appState = .result(sighticInference)
@@ -54,15 +36,17 @@ struct TestView: View {
     }
 
     var body: some View {
-        SighticView(apiKey: "e4c4e2f7-aedc-4462-a74f-5a43967346b9",
-                    completion: { sighticRecordingResult in
-            switch sighticRecordingResult {
-            case .success(let sighticRecording):
-                sendRecodingForAnalysis(sighticRecording)
-            case .failure(let sighticError):
-                appState = .error(sighticError)
-            }
-        })
+        /// The API key e4c4e2f7-aedc-4462-a74f-5a43967346b9 is specific
+        /// for the Quickstart app and shall not be used in production.
+        SighticInferenceView(apiKey: "e4c4e2f7-aedc-4462-a74f-5a43967346b9",
+                    completion: { sighticInferenceRecordingResult in
+                                    switch sighticInferenceRecordingResult {
+                                    case .success(let sighticInferenceRecording):
+                                        sendRecodingForAnalysis(sighticInferenceRecording)
+                                    case .failure(let sighticError):
+                                        appState = .error(sighticError)
+                                    }
+                                })
     }
 }
 

--- a/SighticQuickstartUIKit/SighticQuickstartUIKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SighticQuickstartUIKit/SighticQuickstartUIKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/EyescannerTechnology/sightic-sdk-ios",
       "state" : {
         "branch" : "main",
-        "revision" : "cbffc16a138e78bb603ff53613ae1be2c6e64354"
+        "revision" : "2f590173e97288f19a12da96d0f50ab04a96156c"
       }
     }
   ],

--- a/SighticQuickstartUIKit/SighticQuickstartUIKit/Views/TestViewController.swift
+++ b/SighticQuickstartUIKit/SighticQuickstartUIKit/Views/TestViewController.swift
@@ -6,8 +6,12 @@ import UIKit
 import SwiftUI
 import SighticAnalytics
 
+/// The ``TestViewController`` acts as a container view for the ``SighticInferenceView``.
+///
+/// See https://github.com/EyescannerTechnology/sightic-sdk-ios/blob/main/README.md
+/// regarding how to use the ``SighticInferenceView`` view.
 class TestViewController: UIViewController {
-    func sendRecodingForAnalysis(_ sighticRecording: SighticRecording) {
+    func sendRecodingForAnalysis(_ sighticInferenceRecording: SighticInferenceRecording) {
         Task.init {
             /*
              - The app now has a SighticRecording that we can call
@@ -22,7 +26,7 @@ class TestViewController: UIViewController {
                will be used in the ResultView.
              */
             model.appState = AppState.waiting
-            let inferenceResult = await sighticRecording.performInference()
+            let inferenceResult = await sighticInferenceRecording.performInference()
             switch inferenceResult {
             case .success(let sighticInference):
                 model.appState = .result(sighticInference)
@@ -34,13 +38,15 @@ class TestViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        let sighticView = SighticView(apiKey: "e4c4e2f7-aedc-4462-a74f-5a43967346b9",
+        /// The API key e4c4e2f7-aedc-4462-a74f-5a43967346b9 is specific
+        /// for the Quickstart app and shall not be used in production.
+        let sighticView = SighticInferenceView(apiKey: "e4c4e2f7-aedc-4462-a74f-5a43967346b9",
                                       completion:
-                                        { [weak self] sighticRecordingResult in
+                                        { [weak self] sighticInferenceRecordingResult in
                                           guard let self = self else { return }
-                                          switch sighticRecordingResult {
-                                          case .success(let sighticRecording):
-                                              self.sendRecodingForAnalysis(sighticRecording)
+                                          switch sighticInferenceRecordingResult {
+                                          case .success(let sighticInferenceRecording):
+                                              self.sendRecodingForAnalysis(sighticInferenceRecording)
                                           case .failure(let sighticError):
                                               model.appState = .error(sighticError)
                                       }


### PR DESCRIPTION
* Use `SighticInferenceView` from the SDK instead of the `SighticView`.  
* Update both `SighticQuickstartSwiftUI` and `SighticQuickstartUIKit`
* Use version 0.0.40 of https://github.com/EyescannerTechnology/sightic-sdk-ios which includes https://github.com/EyescannerTechnology/Callisto/pull/47
* Remove comments describing how to use the `SighticInferenceView` and refer to https://github.com/EyescannerTechnology/sightic-sdk-ios/blob/main/README.md instead.