### PR TITLE
Use SDK version 0.0.41

### DIFF
--- a/SighticQuickstartSwiftUI/SighticQuickstartSwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SighticQuickstartSwiftUI/SighticQuickstartSwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/EyescannerTechnology/sightic-sdk-ios",
       "state" : {
         "branch" : "main",
-        "revision" : "2f590173e97288f19a12da96d0f50ab04a96156c"
+        "revision" : "dd4c17a848844f476b5ab1eb3e8a273d4f6868a4"
       }
     }
   ],

--- a/SighticQuickstartSwiftUI/SighticQuickstartSwiftUI/StartView.swift
+++ b/SighticQuickstartSwiftUI/SighticQuickstartSwiftUI/StartView.swift
@@ -1,11 +1,7 @@
-//
-//  Start.swift
-//  SighticQuickstartSwiftUI
-//
 //  Copyright © 2022 Sightic Analytics AB All rights reserved.
-//
 
 import SwiftUI
+import SighticAnalytics
 
 struct StartView: View {
     @Binding var appState: AppState
@@ -14,6 +10,9 @@ struct StartView: View {
         VStack {
             Text("Sightic SDK Quickstart")
                 .font(.title)
+                .padding()
+            Text("SDK version: \(SighticVersion.sdkVersion)")
+                .font(.body)
                 .padding()
             Spacer()
             Text("StartView")

--- a/SighticQuickstartSwiftUI/SighticQuickstartSwiftUI/TestView.swift
+++ b/SighticQuickstartSwiftUI/SighticQuickstartSwiftUI/TestView.swift
@@ -39,7 +39,8 @@ struct TestView: View {
         /// The API key e4c4e2f7-aedc-4462-a74f-5a43967346b9 is specific
         /// for the Quickstart app and shall not be used in production.
         SighticInferenceView(apiKey: "e4c4e2f7-aedc-4462-a74f-5a43967346b9",
-                    completion: { sighticInferenceRecordingResult in
+                             skipInstructions: false,
+                             completion: { sighticInferenceRecordingResult in
                                     switch sighticInferenceRecordingResult {
                                     case .success(let sighticInferenceRecording):
                                         sendRecodingForAnalysis(sighticInferenceRecording)

--- a/SighticQuickstartUIKit/SighticQuickstartUIKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SighticQuickstartUIKit/SighticQuickstartUIKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/EyescannerTechnology/sightic-sdk-ios",
       "state" : {
         "branch" : "main",
-        "revision" : "2f590173e97288f19a12da96d0f50ab04a96156c"
+        "revision" : "dd4c17a848844f476b5ab1eb3e8a273d4f6868a4"
       }
     }
   ],

--- a/SighticQuickstartUIKit/SighticQuickstartUIKit/Views/StartViewController.swift
+++ b/SighticQuickstartUIKit/SighticQuickstartUIKit/Views/StartViewController.swift
@@ -3,6 +3,7 @@
 //
 
 import UIKit
+import SighticAnalytics
 
 class StartViewController: UIViewController {
     override func viewDidLoad() {
@@ -19,16 +20,18 @@ class StartViewController: UIViewController {
         ])
 
         let title = UIQuickstartTitle(title: "Sightic SDK Quickstart")
+        let body1 = UIQuickstartBody(text: "SDK Version: \(SighticVersion.sdkVersion)")
         let spacer1 = UIQuickstartSpacer()
-        let body = UIQuickstartBody(text: "StartView")
+        let body2 = UIQuickstartBody(text: "StartView")
         let button = UIQuickstartButton(title: "Go to test", action: {
             model.appState = .test
         })
         let spacer2 = UIQuickstartSpacer()
 
         sv.addArrangedSubview(title)
+        sv.addArrangedSubview(body1)
         sv.addArrangedSubview(spacer1)
-        sv.addArrangedSubview(body)
+        sv.addArrangedSubview(body2)
         sv.addArrangedSubview(button)
         sv.addArrangedSubview(spacer2)
 

--- a/SighticQuickstartUIKit/SighticQuickstartUIKit/Views/TestViewController.swift
+++ b/SighticQuickstartUIKit/SighticQuickstartUIKit/Views/TestViewController.swift
@@ -41,15 +41,16 @@ class TestViewController: UIViewController {
         /// The API key e4c4e2f7-aedc-4462-a74f-5a43967346b9 is specific
         /// for the Quickstart app and shall not be used in production.
         let sighticView = SighticInferenceView(apiKey: "e4c4e2f7-aedc-4462-a74f-5a43967346b9",
-                                      completion:
-                                        { [weak self] sighticInferenceRecordingResult in
-                                          guard let self = self else { return }
-                                          switch sighticInferenceRecordingResult {
-                                          case .success(let sighticInferenceRecording):
-                                              self.sendRecodingForAnalysis(sighticInferenceRecording)
-                                          case .failure(let sighticError):
-                                              model.appState = .error(sighticError)
-                                      }
+                                               skipInstructions: false,
+                                               completion:
+                                                    { [weak self] sighticInferenceRecordingResult in
+                                                      guard let self = self else { return }
+                                                      switch sighticInferenceRecordingResult {
+                                                      case .success(let sighticInferenceRecording):
+                                                          self.sendRecodingForAnalysis(sighticInferenceRecording)
+                                                      case .failure(let sighticError):
+                                                          model.appState = .error(sighticError)
+                                                  }
                                   })
 
         let sighticViewController = UIHostingController(rootView: sighticView)


### PR DESCRIPTION
* Provide `skipInstructions` to `SighticInferenceView`
* Show SDK version on start page.
* Use `SighticInferenceView` instead of `SighticView`
* Remove comments describing how to use the `SighticInferenceView` and refer to https://github.com/EyescannerTechnology/sightic-sdk-ios/blob/main/README.md instead.