### PR TITLE
SighticQuickstartUIKit: Word wrap in Error View

### DIFF
--- a/SighticQuickstartUIKit/SighticQuickstartUIKit/Views/UILibrary.swift
+++ b/SighticQuickstartUIKit/SighticQuickstartUIKit/Views/UILibrary.swift
@@ -24,6 +24,8 @@ class UIQuickstartBody: UILabel {
         self.text = text
         translatesAutoresizingMaskIntoConstraints = false
         textAlignment = .center
+        numberOfLines = 0
+        lineBreakMode = .byWordWrapping
         font = .preferredFont(forTextStyle: .body)
     }
 


### PR DESCRIPTION
Long error messages not visible in Error View so we fix by doing word wrapping.