### PR TITLE
Remove alignment hint text OK from alignment view when state is countdown.

### DIFF
--- a/SighticQuickstartSwiftUI/SighticQuickstartSwiftUI/AlignmentHintView.swift
+++ b/SighticQuickstartSwiftUI/SighticQuickstartSwiftUI/AlignmentHintView.swift
@@ -80,9 +80,7 @@ struct AlignmentHintLabel: View {
         switch sighticStatus {
         case .align(let sighticAlignmentStatus):
             return sighticAlignmentStatus.message
-        case .countdown:
-            return SighticAlignmentStatus.ok.message
-        case .instruction, .test:
+        case .instruction, .countdown, .test:
             return nil
         @unknown default:
             break

--- a/SighticQuickstartUIKit/SighticQuickstartUIKit/Views/AlignmentHintViewController.swift
+++ b/SighticQuickstartUIKit/SighticQuickstartUIKit/Views/AlignmentHintViewController.swift
@@ -24,9 +24,7 @@ class AlignmentHintViewController: UIViewController {
         switch sighticStatus {
         case .align(let sighticAlignmentStatus):
             alignmentStatusLabel.text = sighticAlignmentStatus.message
-        case .countdown:
-            alignmentStatusLabel.text = SighticAlignmentStatus.ok.message
-        case .instruction, .test:
+        case .instruction, .countdown, .test:
             alignmentStatusLabel.text = ""
         @unknown default:
             break

--- a/SighticQuickstartUIKit/SighticQuickstartUIKit/Views/UILibrary.swift
+++ b/SighticQuickstartUIKit/SighticQuickstartUIKit/Views/UILibrary.swift
@@ -148,6 +148,7 @@ class UIQuickstartAlignmentHint: UIStackView {
         }
         set(newValue) {
             l.text = newValue
+            updateLabelVisibility()
         }
     }
 
@@ -171,6 +172,15 @@ class UIQuickstartAlignmentHint: UIStackView {
             spacer1.heightAnchor.constraint(equalToConstant: 10),
             spacer2.heightAnchor.constraint(equalToConstant: 10)
         ])
+    }
+
+    // Hide label when there is no alignment text to show
+    func updateLabelVisibility() {
+        if let text = l.text, text.isEmpty {
+            l.layer.opacity = 0
+        } else {
+            l.layer.opacity = 0.5
+        }
     }
 
     func createHStackView() -> UIStackView {


### PR DESCRIPTION
Before fix
![before-fix-showing-OK-text](https://user-images.githubusercontent.com/114913386/221536877-a6eacaa6-50c2-422e-847b-c96da96f2d10.png)

After fix
![after-fix-no-OK-text](https://user-images.githubusercontent.com/114913386/221536926-8e1a8856-d27b-4a43-b447-13f3e55160d9.png)
